### PR TITLE
Propose bug fix #1: Escape single quotes in field values

### DIFF
--- a/src/com/merjapp/Merge.java
+++ b/src/com/merjapp/Merge.java
@@ -100,7 +100,7 @@ public class Merge {
 
 			fieldList.add(fieldNames[i]);
 			if (fieldValues[i] instanceof String)
-				valueList.add("'" + fieldValues[i] + "'");
+				valueList.add(String.format("'%s'", fieldValues[i].toString().replace("'", "''")));
 			else
 				valueList.add(fieldValues[i].toString());
 		}


### PR DESCRIPTION
Note: It seems that generally, prepared Statements should be used to
avoid problems like these. Double quotes in field values might still be
a problem after this minor fix.